### PR TITLE
Relax Requires.jl version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [compat]
 Distributions = "0.17,0.18,0.19,0.20,0.21,0.22,0.23"
 ProgressMeter = "1.3"
-Requires = "1.0"
+Requires = "≥ 0.1"
 POMDPModels = "0.4"
 POMDPPlayback = "0.1"
 POMDPPolicies = "0.3"


### PR DESCRIPTION
No need to be restrictive on the `Requires.jl` version (broke compatibility with other projects).